### PR TITLE
Add proper rules config to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,8 +12,8 @@
   "parserOptions": {
     "ecmaVersion": 2018
   },
-  "rules": {
-    "semi": 0,
-    "quotes": 0
+  "rules": {    
+    "quotes": ["error", "double"],
+    "semi": [2, "always"]
   }
 }


### PR DESCRIPTION
I've updated the rules we had in `.eslintrc.json`. Previously we just turned off the rules for semi colons and quotes.

- [Semi-colon rule](https://eslint.org/docs/2.0.0/rules/semi)
```json
// this means you will get eslint error if you don't use semi colon
"semi": [2, "always"]
```

- [Quotes rule](https://eslint.org/docs/rules/quotes)
```json
// this means you will get an eslint error if you don't use double quotes
"quotes": ["error", "double"]
```

